### PR TITLE
[Bugfix] Fix the size of footer in Mdal

### DIFF
--- a/design-system/uilib/src/components/dpdhl-card/dpdhl-card.svelte
+++ b/design-system/uilib/src/components/dpdhl-card/dpdhl-card.svelte
@@ -28,9 +28,9 @@
         height:        calc( 100% - 2 * var(--padding) );
         width:         calc( 100% - 2 * var(--padding) );
 
-        display:               grid;
-        grid-template-columns: 1fr;
-        grid-template-rows:    1fr auto 1fr;
+        display:               flex;
+        flex-direction:        column;
+        justify-content:       space-between;
         gap:                   1rem;
     }
 


### PR DESCRIPTION
Currently all parts of Modal (header, body and footer) are equally big due to Grid. I suggest they should only take as much space as they need. 

**Before:**
<img width="348" alt="Bildschirmfoto 2023-01-06 um 09 44 46" src="https://user-images.githubusercontent.com/43339848/210964879-6673de99-6191-4396-be4a-3276ebbec2fb.png">

**After:**
<img width="347" alt="Bildschirmfoto 2023-01-06 um 09 45 14" src="https://user-images.githubusercontent.com/43339848/210964971-59135c62-73ed-4199-8d1b-2391fa006427.png">


